### PR TITLE
Add logging to Special:Log for events

### DIFF
--- a/TorqueDataConnect/extension.json
+++ b/TorqueDataConnect/extension.json
@@ -59,5 +59,21 @@
     "TorqueDataConnectRaw": false,
     "TorqueDataConnectRenderToHTML": true
   },
+  "LogTypes": [
+    "torquedataconnect-apiaccess",
+    "torquedataconnect-datachanges"
+  ],
+  "LogNames": {
+    "torquedataconnect-apiaccess": "torquedataconnect-apiaccesslog",
+    "torquedataconnect-datachanges": "torquedataconnect-datachangeslog"
+  },
+  "LogHeaders": {
+    "torquedataconnect-apiaccess": "torquedataconnect-apiaccesslog-header",
+    "torquedataconnect-datachanges": "torquedataconnect-datachangeslog-header"
+  },
+  "LogActionsHandlers": {
+    "torquedataconnect-apiaccess/*": "LogFormatter",
+    "torquedataconnect-datachanges/*": "LogFormatter"
+  },
   "manifest_version": 1
 }

--- a/TorqueDataConnect/i18n/en.json
+++ b/TorqueDataConnect/i18n/en.json
@@ -1,8 +1,19 @@
 {
+  "@metadata": {
+    "authors": [
+      "Open Tech Strategies"
+    ]
+  },
   "torquedataconnectattachment": "TorqueDataConnect Attachment",
   "convert-column-page-ne": "$1 does not exist, but is referenced in config as a column config.",
   "convert-id-page-ne": "$1 does not exist, but is referenced in config as a keys config.",
   "mwiki-template-ne": "$1 does not exist, but is referenced in config as a template.",
   "data-config-alert": "Torque Data Configuration Alert!",
-  "config-ne": "Config page $1 does not exist."
+  "config-ne": "Config page $1 does not exist.",
+  "torquedataconnect-apiaccesslog": "Torque Api Access Log",
+  "torquedataconnect-apiaccesslog-header": "Logs events happening in the torque system regarding api access",
+  "torquedataconnect-datachangeslog": "Torque Data Changes Log",
+  "torquedataconnect-datachangeslog-header": "Logs events happening in the torque system regarding data changes",
+  "logentry-torquedataconnect-apiaccess-apiaccess": "$1 accessed the api with path $4",
+  "logentry-torquedataconnect-datachanges-sheetupload": "$1 uploaded a new version of the spreadsheet"
 }

--- a/TorqueDataConnect/include/api/TorqueDataConnectQuery.php
+++ b/TorqueDataConnect/include/api/TorqueDataConnectQuery.php
@@ -6,6 +6,9 @@ class TorqueDataConnectQuery extends APIBase {
   }
 
   public function execute() {
+    $log = new LogPage('torquedataconnect-apiaccess', false);
+    $log->addEntry('apiaccess', $this->getTitle(), null, array($this->getParameter("path")));
+
     $valid_group = TorqueDataConnectConfig::getValidGroup($this->getUser());
 
     global $wgTorqueDataConnectWikiKey;

--- a/TorqueDataConnect/include/api/TorqueDataConnectUploadSheet.php
+++ b/TorqueDataConnect/include/api/TorqueDataConnectUploadSheet.php
@@ -6,6 +6,9 @@ class TorqueDataConnectUploadSheet extends APIBase {
   }
 
   public function execute() {
+    $log = new LogPage('torquedataconnect-datachanges', false);
+    $log->addEntry('sheetupload', $this->getTitle(), null);
+
     parent::checkUserRightsAny(["torquedataconnect-admin"]);
     # We use phpcurl here because it's really straightforward, and
     # research (stackoverflow) didn't produce a compelling native php method.


### PR DESCRIPTION
There are actually two logs being created, one for api access events, and one for data change events.  This is to allow them to be searched for independently.