### PR TITLE
Fix typo in EXAMPLE

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -121,7 +121,7 @@ import mwclient
 host = "yourdomain.tld"
 path = "wiki/"
 scheme = "https"
-attachment_file = "SupportingData.csv"
+attachment_file = "SupportingData.txt"
 
 site = mwclient.Site(host, path=path, scheme=scheme)
 site.login(username, password)


### PR DESCRIPTION
There seems to have been a file type mixup between csv and txt in the example given.