### PR TITLE
Add basic concept of users to torque, create lookup

### DIFF
--- a/TorqueDataConnect/README.md
+++ b/TorqueDataConnect/README.md
@@ -204,6 +204,13 @@ Parameters:
 * `sheet_name` - The name of the sheet this attachment is part of
 * `attachment` - The name of the attachment specified at upload time
 
+### User Lookup
+
+You can access the list of TorqueDataConnect users through the TorqueDataConnectUserLookup
+class.  It only has one method, `lookupByUsername`, but this will allow you to access a
+json object representing the user in MediaWiki.  This user object is currently only a
+username and id, but may get built out later.
+
 ### Search override
 
 Currently TorqueDataConnect takes over the search results and only searches

--- a/TorqueDataConnect/extension.json
+++ b/TorqueDataConnect/extension.json
@@ -21,6 +21,7 @@
   ],
   "AutoloadClasses": {
     "TorqueDataConnectConfig": "include/TorqueDataConnectConfig.php",
+    "TorqueDataConnectUserLookup": "include/TorqueDataConnectUserLookup.php",
     "TorqueDataConnectQuery": "include/api/TorqueDataConnectQuery.php",
     "TorqueDataConnectUploadSheet": "include/api/TorqueDataConnectUploadSheet.php",
     "TorqueDataConnectUploadToc": "include/api/TorqueDataConnectUploadToc.php",

--- a/TorqueDataConnect/include/TorqueDataConnectUserLookup.php
+++ b/TorqueDataConnect/include/TorqueDataConnectUserLookup.php
@@ -1,0 +1,9 @@
+<?php
+class TorqueDataConnectUserLookup {
+  public static function lookupByUsername($username) {
+    $contents = file_get_contents("http://localhost:5000/users/username/$username");
+
+    return json_decode($contents);
+  }
+}
+?>

--- a/torquedata/torquedata/__init__.py
+++ b/torquedata/torquedata/__init__.py
@@ -37,6 +37,12 @@ try:
 except Exception:
     attachment_config = {}
 
+try:
+    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "users"), 'rb') as f:
+        users = pickle.load(f)
+except Exception:
+    users = {}
+
 data = {}
 indices = {}
 def cull_invalid_columns(o, valid_fields):


### PR DESCRIPTION
We need a centralized list of users so that all competitions can refer
to the same set of people, indexed by username.  This adds a starting
point for that, as well as a extension class that MediaWiki can use to
access it.

This should probably be abstracted in the future to some kind of user
class that exists in a database.