### PR TITLE
Move sidebar configuration out of TorqueDataConnect

### DIFF
--- a/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
+++ b/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
@@ -112,26 +112,27 @@ class TorqueDataConnectHooks {
   }
 
   public static function onSidebarBeforeOutput(Skin $skin, &$bar) {
-    # Do this all inline here for now because it's quick, and it would actually
-    # be more confusing to set up the entire javascript infrastructure.  The moment
-    # we do more things with js, this should all get broken out and modularized
-    # correctly!
-    #
-    # Also depending on jquery here, which should get loaded by mediawiki.
-    $out  = "<div style='line-height: 1.125em; font-size: 0.75em'>";
-    $out .= "<select autocomplete=off id='torque-view-select' style='width:130px'";
-    $out .= "onchange='";
-    $out .= "var view = $(\"#torque-view-select\").children(\"option:selected\").val();";
-    $out .= "document.cookie = \"torqueview=\" + view + \"; path=/;\";";
-    $out .= "window.location.reload(true);";
-    $out .= "'>";
-    foreach(TorqueDataConnectConfig::getAvailableViews() as $view) {
-      $selected = (array_key_exists("torqueview", $_COOKIE) && $view == $_COOKIE["torqueview"]) ? " selected=selected" : "";
-      $out .= "<option $selected value='$view'>$view</option>";
+    global $wgTorqueDataConnectSidebarHTML;
+
+    if ($wgTorqueDataConnectSidebarHTML == "") {
+        return true;
     }
-    $out .= "</select>";
-    $out .= "</div>";
-    $bar['View'] = $out;
+
+    $views = TorqueDataConnectConfig::getAvailableViews();
+    if (empty($views)) {
+        return true; // no need for a sidebar (issue #22)
+    }
+
+    $options = "";
+    foreach ($views as $view) {
+      if (array_key_exists("torqueview", $_COOKIE) && $view == $_COOKIE["torqueview"]) {
+        $options .= "<option selected=selected value='$view'>$view</option>";
+      } else {
+        $options .= "<option value='$view'>$view</option>";
+      }
+    }
+
+    $bar['View'] = preg_replace("/{{\s*options\s*}}/", $options, $wgTorqueDataConnectSidebarHTML);
 
     return true;
   }


### PR DESCRIPTION
Sidebar HTML is now defined in a string in LocalSettings.php like this:

```php
$wgTorqueDataConnectSidebarHTML = <<<EOD
<div style='line-height: 1.125em; font-size: 0.75em'>
  <select autocomplete=off id='torque-view-select' style='width: 130px'
          onchange='var view = $("torque-view-select").children("option:selected").val();
                    document.cookie = "torqueview=" + view + "; path=/;";
                    window.location.reload(true);'>
    {{ options }}
  </select>
</div>
EOD;
```

```{{ options }}``` is replaced with the appropriate HTML (```<option>```)

This might change to just defining a callback in LocalSettings.php that generates the sidebar HTML.

(Issue #19)