### PR TITLE
Allow editing of specific fields in torque through mediawiki interface

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -353,6 +353,91 @@ These are done through the MediaWiki API (most likely through a bot account).
 See the [example](EXAMPLE.md) for a better demonstration of how one might
 upload these files.
 
+### Editing data
+
+As per [issue
+#32](https://github.com/opentechstrategies/torque/issues/32), users
+can edit data fields (e.g., to fix a typo in a city's name in the
+"City" field) if they have proper permissions.
+
+Because the original proposal data is inhaled from an on-disk
+spreadsheet at startup time and lives in an in-memory data structure,
+edits are persisted "off to the side" as overlays over that original
+data.  The overlay information is then consulted for updates when
+proposal data is loaded.
+
+For simplicity's sake, we store the edits in their own top-level data
+structure (pickled to and from disk just like the original data is).
+This is what that data structure looks like:
+
+```
+edits = {
+    "proposals": {
+        "1": {
+               "Application #":
+                  [ BASE_HASH,
+                    [
+                      {
+                        "new_value": "15",
+                        "edit_message": "says reason for the edit",
+                        "edit_timestamp": "2020-07-31",
+                        "editor": "JRandom",
+                        "approver": NULL,
+                        "approval_code": NULL,
+                        "approval_timestamp": NULL,
+                      },
+                      {
+                        "new_value": "9",
+                        "edit_message": "says reason for the edit",
+                        "edit_timestamp": "2020-07-29",
+                        "editor": "JRandom",
+                        "approver": NULL,
+                        "approval_code": NULL,
+                        "approval_timestamp": NULL,
+                      },
+                      ...
+                    ]
+                  ]
+                "Name":
+                  [ BASE_HASH,
+                    [
+                      {
+                        "new_value": "Fish",
+                        "edit_message": "says reason for the edit",
+                        "edit_timestamp": "2020-08-12",
+                        "editor": "JRandom",
+                        "approver": NULL,
+                        "approval_code": NULL,
+                        "approval_timestamp": NULL,
+                      },
+                      {
+                        "new_value": "Food",
+                        "edit_message": "says reason for the edit",
+                        "edit_timestamp": "2020-08-07",
+                        "editor": "JRandom",
+                        "approver": NULL,
+                        "approval_code": NULL,
+                        "approval_timestamp": NULL,
+                      },
+                      ...
+                    ]
+                  ]
+             },
+         "2": { ...},
+         ...}
+      }
+```
+
+The edit subdicts are listed in reverse chronological order by
+`edit_timestamp`.  The `BASE_HASH` is a hash of the original value for
+this field, that is, the value that came from the original
+spreadsheet.
+
+The approval fields are unused right now, though they may be used for
+an enhancement to this feature later.  We should decide whether there
+are different meanings for when the approval fields are present but
+NULL versus them just not being present at all.
+
 ### API usage
 
 Normal wiki users can access MediaWiki programmatically through

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -375,8 +375,8 @@ edits = {
     "proposals": {
         "1": {
                "Application #":
-                  [ BASE_HASH,
-                    [
+                  { "original": ORIGINAL_VALUE,
+                    "edits": [
                       {
                         "new_value": "15",
                         "edit_message": "says reason for the edit",
@@ -397,10 +397,10 @@ edits = {
                       },
                       ...
                     ]
-                  ]
+                  }
                 "Name":
-                  [ BASE_HASH,
-                    [
+                  { "original": ORIGINAL_VALUE,
+                    "edits": [
                       {
                         "new_value": "Fish",
                         "edit_message": "says reason for the edit",
@@ -421,7 +421,7 @@ edits = {
                       },
                       ...
                     ]
-                  ]
+                  }
              },
          "2": { ...},
          ...}
@@ -429,9 +429,8 @@ edits = {
 ```
 
 The edit subdicts are listed in reverse chronological order by
-`edit_timestamp`.  The `BASE_HASH` is a hash of the original value for
-this field, that is, the value that came from the original
-spreadsheet.
+`edit_timestamp`. The `ORIGINAL_VALUE` is a copy of the original value for
+this field, that is, the value that came from the original spreadsheet.
 
 The approval fields are unused right now, though they may be used for
 an enhancement to this feature later.  We should decide whether there

--- a/TorqueDataConnect/extension.json
+++ b/TorqueDataConnect/extension.json
@@ -23,6 +23,7 @@
     "TorqueDataConnectConfig": "include/TorqueDataConnectConfig.php",
     "TorqueDataConnectUserLookup": "include/TorqueDataConnectUserLookup.php",
     "TorqueDataConnectQuery": "include/api/TorqueDataConnectQuery.php",
+    "TorqueDataConnectSubmitEdit": "include/api/TorqueDataConnectSubmitEdit.php",
     "TorqueDataConnectUploadSheet": "include/api/TorqueDataConnectUploadSheet.php",
     "TorqueDataConnectUploadToc": "include/api/TorqueDataConnectUploadToc.php",
     "TorqueDataConnectUploadAttachment": "include/api/TorqueDataConnectUploadAttachment.php",
@@ -40,6 +41,7 @@
   },
   "APIModules": {
     "torquedataconnect": "TorqueDataConnectQuery",
+    "torquedataconnectsubmitedit": "TorqueDataConnectSubmitEdit",
     "torquedataconnectuploadsheet": "TorqueDataConnectUploadSheet",
     "torquedataconnectuploadtoc": "TorqueDataConnectUploadToc",
     "torquedataconnectuploadattachment": "TorqueDataConnectUploadAttachment"
@@ -77,6 +79,29 @@
   "LogActionsHandlers": {
     "torquedataconnect-apiaccess/*": "LogFormatter",
     "torquedataconnect-datachanges/*": "LogFormatter"
+  },
+  "ResourceModules": {
+    "ext.torquedataconnect.css": {
+      "styles": "resources/css/TorqueDataConnectEdit.css",
+      "targets": [
+        "desktop",
+        "mobile"
+      ]
+    },
+    "ext.torquedataconnect.js": {
+      "scripts": "resources/js/TorqueDataConnectEdit.js",
+      "dependencies": [ "mediawiki.api" ],
+      "messages": [
+      ],
+      "targets": [
+        "desktop",
+        "mobile"
+      ]
+    }
+  },
+  "ResourceFileModulePaths": {
+    "localBasePath": "",
+    "remoteExtPath": "TorqueDataConnect"
   },
   "manifest_version": 1
 }

--- a/TorqueDataConnect/extension.json
+++ b/TorqueDataConnect/extension.json
@@ -17,7 +17,8 @@
     ]
   },
   "AvailableRights": [
-    "torquedataconnect-admin"
+    "torquedataconnect-admin",
+    "torquedataconnect-edit"
   ],
   "AutoloadClasses": {
     "TorqueDataConnectConfig": "include/TorqueDataConnectConfig.php",
@@ -38,7 +39,8 @@
     "SiteNoticeAfter": "TorqueDataConnectHooks::siteNoticeAfter",
     "SpecialSearchResultsPrepend": "TorqueDataConnectHooks::onSpecialSearchResultsPrepend",
     "SidebarBeforeOutput": "TorqueDataConnectHooks::onSidebarBeforeOutput",
-    "BaseTemplateToolbox": "TorqueDataConnectHooks::onBaseTemplateToolbox"
+    "BaseTemplateToolbox": "TorqueDataConnectHooks::onBaseTemplateToolbox",
+    "BeforePageDisplay": "TorqueDataConnectHooks::onBeforePageDisplay"
   },
   "APIModules": {
     "torquedataconnect": "TorqueDataConnectQuery",

--- a/TorqueDataConnect/extension.json
+++ b/TorqueDataConnect/extension.json
@@ -24,6 +24,7 @@
     "TorqueDataConnectUserLookup": "include/TorqueDataConnectUserLookup.php",
     "TorqueDataConnectQuery": "include/api/TorqueDataConnectQuery.php",
     "TorqueDataConnectSubmitEdit": "include/api/TorqueDataConnectSubmitEdit.php",
+    "TorqueDataConnectQueryCell": "include/api/TorqueDataConnectQueryCell.php",
     "TorqueDataConnectUploadSheet": "include/api/TorqueDataConnectUploadSheet.php",
     "TorqueDataConnectUploadToc": "include/api/TorqueDataConnectUploadToc.php",
     "TorqueDataConnectUploadAttachment": "include/api/TorqueDataConnectUploadAttachment.php",
@@ -41,6 +42,7 @@
   },
   "APIModules": {
     "torquedataconnect": "TorqueDataConnectQuery",
+    "torquedataconnectquerycell": "TorqueDataConnectQueryCell",
     "torquedataconnectsubmitedit": "TorqueDataConnectSubmitEdit",
     "torquedataconnectuploadsheet": "TorqueDataConnectUploadSheet",
     "torquedataconnectuploadtoc": "TorqueDataConnectUploadToc",
@@ -49,7 +51,7 @@
   "ExtensionMessagesFiles": {
     "TorqueDataConnectMagic": "TorqueDataConnect.i18n.php",
     "TorqueDataConnectAlias": "TorqueDataConnect.i18n.alias.php"
-	},
+  },
   "SpecialPages": {
     "TorqueDataConnectAttachment": "TorqueDataConnectAttachment"
   },
@@ -90,9 +92,10 @@
     },
     "ext.torquedataconnect.js": {
       "scripts": "resources/js/TorqueDataConnectEdit.js",
-      "dependencies": [ "mediawiki.api" ],
-      "messages": [
+      "dependencies": [
+        "mediawiki.api"
       ],
+      "messages": [],
       "targets": [
         "desktop",
         "mobile"

--- a/TorqueDataConnect/i18n/en.json
+++ b/TorqueDataConnect/i18n/en.json
@@ -17,5 +17,6 @@
   "torquedataconnect-datachangeslog-header": "Logs events happening in the torque system regarding data changes",
   "logentry-torquedataconnect-apiaccess-apiaccess": "$1 accessed the api with path $4",
   "logentry-torquedataconnect-datachanges-sheetupload": "$1 uploaded a new version of the spreadsheet",
+  "logentry-torquedataconnect-datachanges-edit": "$1 edited field \"$4\" on page $3",
   "torquedataconnect-sidebar-configpage": "Torque Configuration"
 }

--- a/TorqueDataConnect/include/api/TorqueDataConnectQueryCell.php
+++ b/TorqueDataConnect/include/api/TorqueDataConnectQueryCell.php
@@ -1,0 +1,52 @@
+
+<?php
+class TorqueDataConnectQueryCell extends APIBase {
+
+  public function __construct($main, $action) {
+    parent::__construct($main, $action);
+  }
+
+  public function execute() {
+    $valid_group = TorqueDataConnectConfig::getValidGroup($this->getUser());
+    global $wgTorqueDataConnectWikiKey, $wgTorqueDataConnectServerLocation;
+
+    #/api/<sheet_name>/id/<key>/<field>
+    $sheetName = $this->getParameter('sheetName');
+    $key = $this->getParameter('key');
+    $field = $this->getParameter('field');
+
+    $url = $wgTorqueDataConnectServerLocation .
+      '/api/' .
+      $sheetName .
+      '/id/' .
+      $key . "/" .
+      rawurlencode($field) .
+      "?group=" . $valid_group .
+      "&wiki_key=" . $wgTorqueDataConnectWikiKey;
+
+    $contents = file_get_contents($url);
+
+    $response = json_decode($contents);
+    foreach($response as $name => $value) {
+      $this->getResult()->addValue(null, $name, $value);
+    }
+  }
+
+  public function getAllowedParams() {
+    return [
+      "sheetName" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+      "key" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+      "field" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+    ];
+  }
+}
+?>

--- a/TorqueDataConnect/include/api/TorqueDataConnectSubmitEdit.php
+++ b/TorqueDataConnect/include/api/TorqueDataConnectSubmitEdit.php
@@ -42,7 +42,8 @@ class TorqueDataConnectSubmitEdit extends APIBase {
     curl_close($ch);
 
     $parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
-    $po= $parser->parse($result, $title, ParserOptions::newCanonical());
+    $text = (new WikiPage($title))->getContent()->getText();
+    $po= $parser->parse($text, $title, ParserOptions::newFromUser($this->getUser()));
     $this->getResult()->addValue(null, 'html', $po->getText());
   }
 

--- a/TorqueDataConnect/include/api/TorqueDataConnectSubmitEdit.php
+++ b/TorqueDataConnect/include/api/TorqueDataConnectSubmitEdit.php
@@ -1,0 +1,74 @@
+
+<?php
+class TorqueDataConnectSubmitEdit extends APIBase {
+
+  public function __construct($main, $action) {
+    parent::__construct($main, $action);
+  }
+
+  public function execute() {
+    $valid_group = TorqueDataConnectConfig::getValidGroup($this->getUser());
+    global $wgTorqueDataConnectWikiKey, $wgTorqueDataConnectServerLocation;
+
+    $newValues = $this->getParameter('newValues');
+    $field = array_keys(json_decode($newValues, true))[0];
+    $sheetName = $this->getParameter('sheetName');
+    $key = $this->getParameter('key');
+    $title = Title::newFromText($this->getParameter('title'));
+    $log = new LogPage('torquedataconnect-datachanges',false);
+    $log->addEntry('edit', $title, null, $field);
+
+    $url = $wgTorqueDataConnectServerLocation .
+      '/api/' .
+      $sheetName .
+      '/edit-record/' .
+      $key;
+
+    $ch = curl_init( $url );
+    # Setup request to send json via POST.
+    $payload = json_encode(
+      array(
+        "new_values" => $newValues,
+        "wiki_key" => $wgTorqueDataConnectWikiKey,
+        "group" => $valid_group,
+      )
+    );
+    curl_setopt( $ch, CURLOPT_POSTFIELDS, $payload );
+    curl_setopt( $ch, CURLOPT_HTTPHEADER, array('Content-Type:application/json'));
+    # Return response instead of printing.
+    curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+    # Send request.
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    $parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
+    $po= $parser->parse($result, $title, ParserOptions::newCanonical());
+    $this->getResult()->addValue(null, 'html', $po->getText());
+  }
+
+  public function mustBePosted() {
+    return true;
+  }
+
+  public function getAllowedParams() {
+    return [
+      "newValues" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+      "sheetName" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+      "key" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+      "title" => [
+        ApiBase::PARAM_TYPE => 'string',
+        ApiBase::PARAM_REQUIRED => 'true'
+      ],
+    ];
+  }
+}
+?>

--- a/TorqueDataConnect/include/api/TorqueDataConnectSubmitEdit.php
+++ b/TorqueDataConnect/include/api/TorqueDataConnectSubmitEdit.php
@@ -10,6 +10,7 @@ class TorqueDataConnectSubmitEdit extends APIBase {
     $valid_group = TorqueDataConnectConfig::getValidGroup($this->getUser());
     global $wgTorqueDataConnectWikiKey, $wgTorqueDataConnectServerLocation;
 
+    parent::checkUserRightsAny(["torquedataconnect-edit"]);
     $newValues = $this->getParameter('newValues');
     $field = array_keys(json_decode($newValues, true))[0];
     $sheetName = $this->getParameter('sheetName');

--- a/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
+++ b/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
@@ -6,7 +6,10 @@ class TorqueDataConnectHooks {
 	}
 
 	public static function loadLocation($parser, $location, $view = false) {
-  	$parser->disableCache();
+    $parser->disableCache();
+    $po = $parser->getOutput();
+    $po->addModules('ext.torquedataconnect.js');
+    $po->addModuleStyles('ext.torquedataconnect.css');
 
     global $wgTorqueDataConnectGroup, $wgTorqueDataConnectRenderToHTML, $wgTorqueDataConnectView,
       $wgTorqueDataConnectRaw, $wgTorqueDataConnectWikiKey, $wgTorqueDataConnectServerLocation;
@@ -26,6 +29,8 @@ class TorqueDataConnectHooks {
       $wgTorqueDataConnectWikiKey .
       ($view ? "&view=" . $view : "")
       );
+    
+    $contents = $contents . '<span id="page-info" data-location="' . $location . '"></span>';
 
     # If there are parser hooks in the output of the template, then
     # then we need to parse it fully, and let mediawiki know that

--- a/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
+++ b/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
@@ -169,6 +169,12 @@ class TorqueDataConnectHooks {
 
     return true;
   }
+
+  public static function onBeforePageDisplay(OutputPage $out, Skin $skin) {
+    $rights = $skin->getUser()->getRights();
+    $script = "<script>window.userRights = [\"" . implode("\",\"", $rights) . "\"];</script>";
+    $out->addScript($script);
+  }
 }
 
 ?>

--- a/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
+++ b/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
@@ -19,6 +19,13 @@ class TorqueDataConnectHooks {
       $view = $wgTorqueDataConnectView;
     }
 
+    // If this isn't set, that means we've gotten here through some other means, and we
+    // should just grab whatever group is correct for the current user.
+    if(!$wgTorqueDataConnectGroup) {
+      global $wgUser;
+      $wgTorqueDataConnectGroup = TorqueDataConnectConfig::getValidGroup($wgUser);
+    }
+
     $contents = file_get_contents(
       $wgTorqueDataConnectServerLocation .
       "/api/" .

--- a/TorqueDataConnect/resources/css/TorqueDataConnectEdit.css
+++ b/TorqueDataConnect/resources/css/TorqueDataConnectEdit.css
@@ -1,0 +1,60 @@
+.torque-edit:hover {
+    text-decoration: underline;
+}
+
+.torque-edit::before {
+    content: "[" ;
+    color: black;
+}
+.torque-edit::after {
+    content: "]" ;
+    color: black;
+}
+
+.torque-edit-button {
+    color: #0645ad;
+    display: inline-block;
+}
+
+.torque-edit-button.paragraph {
+    padding-left: 1em;
+}
+
+table p {
+    display: inline;
+}
+
+.torque-edit-button:hover {
+    background: transparent;
+    cursor: pointer;
+}
+
+.torque-save-wrapper {
+    display: flex;
+}
+
+.torque-save-wrapper > span {
+    color: #FFF;
+    font-weight: bold;
+    padding: 4px 0;
+    text-align: center;
+    flex: 0 0 50%;
+}
+
+.torque-save-wrapper > span:hover {
+    filter: brightness(120%);
+    cursor: pointer;
+}
+
+.torque-save {
+    background-color: #3870D3;
+}
+
+.torque-save-cancel {
+    background-color:  	#CD5C5C;
+}
+
+.torque-main-content > p {
+    display: inline;
+    padding-left: 0 !important;
+}

--- a/TorqueDataConnect/resources/css/TorqueDataConnectEdit.css
+++ b/TorqueDataConnect/resources/css/TorqueDataConnectEdit.css
@@ -31,6 +31,7 @@ table p {
 
 .torque-save-wrapper {
     display: flex;
+    justify-content: space-between;
 }
 
 .torque-save-wrapper > span {
@@ -38,20 +39,21 @@ table p {
     font-weight: bold;
     padding: 4px 0;
     text-align: center;
-    flex: 0 0 50%;
 }
 
 .torque-save-wrapper > span:hover {
-    filter: brightness(120%);
+    filter: brightness(80%);
     cursor: pointer;
 }
 
 .torque-save {
     background-color: #3870D3;
+    width: 75%;
 }
 
 .torque-save-cancel {
-    background-color:  	#CD5C5C;
+    background-color:	#C8CCD1;
+    width: 20%;
 }
 
 .torque-main-content > p {

--- a/TorqueDataConnect/resources/css/TorqueDataConnectEdit.css
+++ b/TorqueDataConnect/resources/css/TorqueDataConnectEdit.css
@@ -11,9 +11,14 @@
     color: black;
 }
 
+body.show-edit .torque-edit-button {
+    visibility: visible !important;
+}
+
 .torque-edit-button {
     color: #0645ad;
     display: inline-block;
+    visibility: hidden;
 }
 
 .torque-edit-button.paragraph {

--- a/TorqueDataConnect/resources/js/TorqueDataConnectEdit.js
+++ b/TorqueDataConnect/resources/js/TorqueDataConnectEdit.js
@@ -12,7 +12,10 @@ function addEditButtonListeners () {
 }
 
 $(document).ready(() => {
-    addEditButtonListeners();
+    if (window.userRights.includes("torquedataconnect-edit")) {
+        $('body').toggleClass('show-edit');
+        addEditButtonListeners();
+    }
 });
 
 async function submitEdit (field, value) {
@@ -39,6 +42,7 @@ async function submitEdit (field, value) {
             dataType: "json",
         });
         $('.torque-wrapper').replaceWith(results.html);
+        $('.torque-edit-button').css("visibility", "visible");
         addEditButtonListeners();
     } catch (error) {
         console.error(error);

--- a/TorqueDataConnect/resources/js/TorqueDataConnectEdit.js
+++ b/TorqueDataConnect/resources/js/TorqueDataConnectEdit.js
@@ -1,0 +1,224 @@
+/*@nomin*/
+function addEditButtonListeners () {
+    $(".torque-edit-button.paragraph").click(handleParagraphEdit);
+    $(".torque-edit-button.list").click(handleListEdit);
+
+    const [sheetName, , key] = $("#page-info")
+        .data("location")
+        .replace(".mwiki", "")
+        .split("/");
+    window.sheetName = sheetName;
+    window.key = key;
+}
+
+$(document).ready(() => {
+    addEditButtonListeners();
+});
+
+async function submitEdit (field, value, callback) {
+    const postData = {
+        newValues: JSON.stringify({ [field]: value }),
+        sheetName: window.sheetName,
+        key: window.key,
+        title: mw.config.values.wgTitle,
+    };
+    try {
+        // Gets CORS token for POST
+        const corsResult = await $.ajax({
+            type: "GET",
+            url: "/lfc/api.php?action=query&format=json&meta=tokens",
+            dataType: "json",
+        });
+
+        const token = encodeURIComponent(corsResult.query.tokens.csrftoken);
+        const actionName = "torquedataconnectsubmitedit";
+        const results = await $.ajax({
+            type: "POST",
+            url: `${mw.config.values.wgScriptPath}/api.php?action=${actionName}&format=json&token=${token}`,
+            data: postData,
+            dataType: "json",
+        });
+        $('.torque-wrapper').replaceWith(results.html);
+        addEditButtonListeners();
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+const textArea = (v) => $(`<textarea name="" type="text">${v}</textarea>`);
+// Returns a jquery cancel and save button side-by-side
+const saveButtons = (fieldName, originalValue, onCancel, onSave) => {
+    const cancelBtn = $('<span class="torque-save-cancel">Cancel</span>');
+    cancelBtn.data("original", originalValue);
+    cancelBtn.click(onCancel);
+    const saveBtn = $('<span class="torque-save">Save</span>');
+    saveBtn.data("field", fieldName);
+    saveBtn.click(onSave);
+    return $(`<div id="${fieldName}" class="torque-save-wrapper"></div>`)
+        .append(cancelBtn)
+        .append(saveBtn);
+};
+const editButton = (type, field) => {
+    return $(
+        `<div class="torque-edit-button ${type}"><div class="torque-edit">edit</div></div>`
+    )
+        .data("type", type)
+        .data("field", field);
+};
+
+// Paragraph event listeners
+const handleParagraphEdit = (e) => {
+    const target = $(e.currentTarget);
+    const sibling = $(e.currentTarget.previousSibling);
+    const text = sibling[0].innerText;
+    const field = target.data("field");
+    const newInput = textArea(text)
+    sibling.replaceWith(newInput);
+    target.replaceWith(
+        saveButtons(
+            field,
+            text,
+            handleParagraphSaveCancel,
+            handleParagraphSave
+        )
+    );
+
+    newInput[0].style.height = `${newInput[0].scrollHeight}px`;
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+};
+
+const substituteParagraphValue = (sibling, target, newValue, field) => {
+    sibling.replaceWith(`<p>${newValue}</p>`);
+    const editBtn = editButton("paragraph", field);
+    editBtn.click(handleParagraphEdit);
+    target.replaceWith(editBtn);
+};
+
+const handleParagraphSaveCancel = (e) => {
+    const target = $(e.target);
+    const sibling = $(e.target).parent().prev();
+    const newValue = target.data("original");
+    const field = target.next().data("field");
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+    console.log(field);
+    substituteParagraphValue(sibling, target.parent(), newValue, field);
+};
+
+const handleParagraphSave = (e) => {
+    const target = $(e.target);
+    const sibling = $(e.target).parent().prev();
+    const newValue = sibling[0].value;
+    const field = target.data("field");
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+    submitEdit(field, newValue);
+    substituteParagraphValue(sibling, target.parent(), newValue, field);
+};
+
+// Unordered list event listeners
+const handleListEdit = (e) => {
+    const clickedButton = $(e.currentTarget);
+    let dataField = $(e.currentTarget).prev();
+    let listElements = [];
+    while (dataField[0].nodeName == "UL") {
+        listElements.unshift(dataField);
+        dataField = dataField.prev();
+    }
+
+    const val = listElements.map((e) => e[0].querySelector('.editable').innerText);
+    const field = clickedButton.data("field");
+
+    for (let e of listElements) {
+        e.remove();
+    }
+
+    const newInput = textArea(val.join("\n")).add(
+        saveButtons(
+            field,
+            listElements.map(e => e.find('li').html()).join('\n'),
+            handleListSaveCancel,
+            handleListSave
+        )
+    )
+
+    clickedButton.replaceWith(newInput);
+    newInput[0].style.height = `${newInput[0].scrollHeight}px`;
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+};
+
+const substituteListValue = (sibling, target, newValue, field) => {
+    let listElements = "";
+    for (let l of newValue.split("\n")) {
+        listElements += `<ul><li>${l}</li></ul>`;
+    }
+    sibling.replaceWith(listElements);
+    const btn = $(editButton("list", field));
+    btn.click(handleListEdit);
+    target.replaceWith(btn);
+};
+
+const handleListSaveCancel = (e) => {
+    const target = $(e.target);
+    const sibling = $(e.target).parent().prev();
+    const newValue = target.data("original");
+    const field = target.next().data("field");
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+    substituteListValue(sibling, target.parent(), newValue, field);
+};
+
+const handleListSave = (e) => {
+    const target = $(e.target);
+    const sibling = $(e.target).parent().prev();
+    const newValue = sibling[0].value;
+    const field = target.data("field");
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+    submitEdit(field, newValue.split("\n"));
+    substituteListValue(sibling, target.parent(), newValue, field);
+};
+
+// Paragraph event listeners
+const handleInlineEdit = (e) => {
+    const target = $(e.currentTarget);
+    const sibling = $(e.currentTarget.previousSibling);
+    const text = sibling[0].innerText;
+    const field = target.data("field");
+    const newInput = textArea(text)
+    sibling.replaceWith(newInput);
+    target.replaceWith(
+        saveButtons(
+            field,
+            text,
+            handleParagraphSaveCancel,
+            handleParagraphSave
+        )
+    );
+
+    newInput[0].style.height = `${newInput[0].scrollHeight}px`;
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+};
+
+const substituteInlineValue = (sibling, target, newValue, field) => {
+    sibling.replaceWith(`<p>${newValue}</p>`);
+    const editBtn = editButton("paragraph", field);
+    editBtn.click(handleParagraphEdit);
+    target.replaceWith(editBtn);
+};
+
+const handleInlineSaveCancel = (e) => {
+    const target = $(e.target);
+    const sibling = $(e.target).parent().prev();
+    const newValue = target.data("original");
+    const field = target.next().data("field");
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+    console.log(field);
+    substituteParagraphValue(sibling, target.parent(), newValue, field);
+};
+
+const handleInlineSave = (e) => {
+    const target = $(e.target);
+    const sibling = $(e.target).parent().prev();
+    const newValue = sibling[0].value;
+    const field = target.data("field");
+    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
+    submitEdit(field, newValue);
+    substituteParagraphValue(sibling, target.parent(), newValue, field);
+};

--- a/TorqueDataConnect/resources/js/TorqueDataConnectEdit.js
+++ b/TorqueDataConnect/resources/js/TorqueDataConnectEdit.js
@@ -84,7 +84,6 @@ const handleParagraphEdit = (e) => {
     );
 
     newInput[0].style.height = `${newInput[0].scrollHeight}px`;
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
 };
 
 const substituteParagraphValue = (sibling, target, newValue, field) => {
@@ -99,8 +98,6 @@ const handleParagraphSaveCancel = (e) => {
     const sibling = $(e.target).parent().prev();
     const newValue = target.data("original");
     const field = target.next().data("field");
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
-    console.log(field);
     substituteParagraphValue(sibling, target.parent(), newValue, field);
 };
 
@@ -109,7 +106,6 @@ const handleParagraphSave = (e) => {
     const sibling = $(e.target).parent().prev();
     const newValue = sibling[0].value;
     const field = target.data("field");
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
     submitEdit(field, newValue);
     substituteParagraphValue(sibling, target.parent(), newValue, field);
 };
@@ -142,7 +138,6 @@ const handleListEdit = (e) => {
 
     clickedButton.replaceWith(newInput);
     newInput[0].style.height = `${newInput[0].scrollHeight}px`;
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
 };
 
 const substituteListValue = (sibling, target, newValue, field) => {
@@ -161,7 +156,6 @@ const handleListSaveCancel = (e) => {
     const sibling = $(e.target).parent().prev();
     const newValue = target.data("original");
     const field = target.next().data("field");
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
     substituteListValue(sibling, target.parent(), newValue, field);
 };
 
@@ -170,7 +164,6 @@ const handleListSave = (e) => {
     const sibling = $(e.target).parent().prev();
     const newValue = sibling[0].value;
     const field = target.data("field");
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
     submitEdit(field, newValue.split("\n"));
     substituteListValue(sibling, target.parent(), newValue, field);
 };
@@ -193,7 +186,6 @@ const handleInlineEdit = (e) => {
     );
 
     newInput[0].style.height = `${newInput[0].scrollHeight}px`;
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
 };
 
 const substituteInlineValue = (sibling, target, newValue, field) => {
@@ -208,8 +200,6 @@ const handleInlineSaveCancel = (e) => {
     const sibling = $(e.target).parent().prev();
     const newValue = target.data("original");
     const field = target.next().data("field");
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
-    console.log(field);
     substituteParagraphValue(sibling, target.parent(), newValue, field);
 };
 
@@ -218,7 +208,6 @@ const handleInlineSave = (e) => {
     const sibling = $(e.target).parent().prev();
     const newValue = sibling[0].value;
     const field = target.data("field");
-    console.log($(`#${$.escapeSelector(field)} > .torque-save`).data("field"));
     submitEdit(field, newValue);
     substituteParagraphValue(sibling, target.parent(), newValue, field);
 };

--- a/torquedata/torquedata/__init__.py
+++ b/torquedata/torquedata/__init__.py
@@ -12,39 +12,41 @@ from whoosh.fields import *
 app = Flask(__name__)
 
 try:
-    app.config.from_object('config')
+    app.config.from_object("config")
 except:
     pass
 
 sheet_config = configparser.ConfigParser()
-sheet_config.read(os.path.join(app.config['SPREADSHEET_FOLDER'], "sheets"))
+sheet_config.read(os.path.join(app.config["SPREADSHEET_FOLDER"], "sheets"))
 
 try:
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "permissions"), 'rb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "permissions"), "rb") as f:
         permissions = pickle.load(f)
 except Exception:
     permissions = {}
 
 try:
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "templates"), 'rb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "templates"), "rb") as f:
         templates = pickle.load(f)
 except Exception:
     templates = {}
 
 try:
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "attachment_config"), 'rb') as f:
+    with open(
+        os.path.join(app.config["SPREADSHEET_FOLDER"], "attachment_config"), "rb"
+    ) as f:
         attachment_config = pickle.load(f)
 except Exception:
     attachment_config = {}
 
 try:
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "users"), 'rb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "users"), "rb") as f:
         users = pickle.load(f)
 except Exception:
     users = {}
 
 try:
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "edits"), 'rb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "edits"), "rb") as f:
         edits = pickle.load(f)
         load_edits = False
 except Exception:
@@ -57,7 +59,7 @@ indices = {}
 
 
 def cull_invalid_columns(o, valid_fields):
-    return {k:v for (k, v) in o.items() if (k in valid_fields)}
+    return {k: v for (k, v) in o.items() if (k in valid_fields)}
 
 
 def cull_invalid_objects(group, sheet_name, wiki_key):
@@ -68,8 +70,12 @@ def cull_invalid_objects(group, sheet_name, wiki_key):
     if group not in permissions[sheet_name][wiki_key].keys():
         return []
     elif "valid_ids" in permissions[sheet_name][wiki_key][group].keys():
-        valid_ids = permissions[sheet_name][wiki_key][group]["valid_ids"];
-        return [ o for o in data[sheet_name].values() if (o[sheet_config[sheet_name]["key_column"]] in valid_ids) ]
+        valid_ids = permissions[sheet_name][wiki_key][group]["valid_ids"]
+        return [
+            o
+            for o in data[sheet_name].values()
+            if (o[sheet_config[sheet_name]["key_column"]] in valid_ids)
+        ]
     else:
         return list(data[sheet_name].values())
 
@@ -78,8 +84,8 @@ def update_row_with_edits(row, sheet_name, key):
     row_edits = edits[sheet_name][key]
 
     for k in row:
-        if len(row_edits[k]['edits']) > 0:
-            row[k] = row_edits[k]['edits'][-1]['new_value']
+        if len(row_edits[k]["edits"]) > 0:
+            row[k] = row_edits[k]["edits"][-1]["new_value"]
 
     return row
 
@@ -88,18 +94,26 @@ def permissions_sha(sheet_name, wiki_key, group):
     import hashlib
 
     return hashlib.sha224(
-        sheet_name.encode('utf-8') +
-        str(permissions[sheet_name][wiki_key][group]["valid_ids"]).encode('utf-8') +
-        str(permissions[sheet_name][wiki_key][group]["columns"]).encode('utf-8')
+        sheet_name.encode("utf-8")
+        + str(permissions[sheet_name][wiki_key][group]["valid_ids"]).encode("utf-8")
+        + str(permissions[sheet_name][wiki_key][group]["columns"]).encode("utf-8")
     ).hexdigest()
 
 
 def index_search(group, sheet_name, wiki_key):
     sha = permissions_sha(sheet_name, wiki_key, group)
-    dir = os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "indices", sha)
+    dir = os.path.join(app.config["SPREADSHEET_FOLDER"], sheet_name, "indices", sha)
 
-    if(index.exists_in(dir)):
-        print("Index already exists for " + sheet_name + " / " + wiki_key + " / " + group + " (or comparable)")
+    if index.exists_in(dir):
+        print(
+            "Index already exists for "
+            + sheet_name
+            + " / "
+            + wiki_key
+            + " / "
+            + group
+            + " (or comparable)"
+        )
         ix = index.open_dir(dir)
         indices[sha] = ix
         return
@@ -115,9 +129,16 @@ def index_search(group, sheet_name, wiki_key):
     writer = ix.writer()
     for o in cull_invalid_objects(group, sheet_name, wiki_key):
         writer.add_document(
-                key=o[sheet_config[sheet_name]["key_column"]],
-                content=" ".join([str(c) for c in cull_invalid_columns(o, permissions[sheet_name][wiki_key][group]["columns"]).values()])
-                )
+            key=o[sheet_config[sheet_name]["key_column"]],
+            content=" ".join(
+                [
+                    str(c)
+                    for c in cull_invalid_columns(
+                        o, permissions[sheet_name][wiki_key][group]["columns"]
+                    ).values()
+                ]
+            ),
+        )
     writer.commit()
 
     indices[sha] = ix
@@ -129,10 +150,15 @@ def load_sheet(sheet_name):
     data[sheet_name] = {}
     loaded_edits = {}
     reader = csv.reader(
-            open(os.path.join(app.config.get("SPREADSHEET_FOLDER"), sheet_name, sheet_name + ".csv"), encoding='utf-8'),
-            delimiter=',',
-            quotechar='"'
-            )
+        open(
+            os.path.join(
+                app.config.get("SPREADSHEET_FOLDER"), sheet_name, sheet_name + ".csv"
+            ),
+            encoding="utf-8",
+        ),
+        delimiter=",",
+        quotechar='"',
+    )
 
     if sheet_name not in templates:
         templates[sheet_name] = {}
@@ -146,16 +172,16 @@ def load_sheet(sheet_name):
         o = {}
         edit_o = {}
         for (field, column_type, cell) in zip(header, column_types, row):
-            if column_type == 'list':
+            if column_type == "list":
                 # This may be reversed as a decision at some point, but the empty cell
                 # from the csv comes through as the empty string, meaning that the user
                 # probably wants the list to be empty as well.
-                if cell == '':
+                if cell == "":
                     cell = []
                 else:
                     cell = cell.strip().split("\n")
-            elif column_type == 'json':
-                if cell == '':
+            elif column_type == "json":
+                if cell == "":
                     cell = {}
                 else:
                     cell = json.loads(cell)
@@ -166,16 +192,18 @@ def load_sheet(sheet_name):
         for k, v in o.items():
             loaded_edits[o[sheet_config[sheet_name]["key_column"]]][k] = {
                 "original": v,
-                "edits": []
+                "edits": [],
             }
-    
+
     if load_edits:
         edits[sheet_name] = loaded_edits
 
     for wiki_key in permissions[sheet_name].keys():
         for group in permissions[sheet_name][wiki_key].keys():
             sha = permissions_sha(sheet_name, wiki_key, group)
-            dir = os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, wiki_key, "indices", sha)
+            dir = os.path.join(
+                app.config["SPREADSHEET_FOLDER"], sheet_name, wiki_key, "indices", sha
+            )
             index_search(group, sheet_name, wiki_key)
 
 

--- a/torquedata/torquedata/__init__.py
+++ b/torquedata/torquedata/__init__.py
@@ -48,12 +48,9 @@ except Exception:
 try:
     with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "edits"), "rb") as f:
         edits = pickle.load(f)
-        load_edits = False
 except Exception:
     edits = {}
-    load_edits = True
 
-loaded_edits = {}
 data = {}
 indices = {}
 
@@ -148,7 +145,12 @@ def index_search(group, sheet_name, wiki_key):
 
 def load_sheet(sheet_name):
     data[sheet_name] = {}
-    loaded_edits = {}
+
+    if sheet_name not in edits.keys():
+        edits[sheet_name] = {}
+
+    loaded_edits = edits[sheet_name]
+
     reader = csv.reader(
         open(
             os.path.join(
@@ -185,17 +187,19 @@ def load_sheet(sheet_name):
                 else:
                     cell = json.loads(cell)
             o[field] = cell
-        data[sheet_name][o[sheet_config[sheet_name]["key_column"]]] = o
-        loaded_edits[o[sheet_config[sheet_name]["key_column"]]] = {}
+
+        object_key = o[sheet_config[sheet_name]["key_column"]]
+        data[sheet_name][object_key] = o
+
+        if object_key not in loaded_edits.keys():
+            loaded_edits[object_key] = {}
 
         for k, v in o.items():
-            loaded_edits[o[sheet_config[sheet_name]["key_column"]]][k] = {
-                "original": v,
-                "edits": [],
-            }
-
-    if load_edits:
-        edits[sheet_name] = loaded_edits
+            if k not in loaded_edits[object_key].keys():
+                loaded_edits[object_key][k] = {
+                    "original": v,
+                    "edits": [],
+                }
 
     for wiki_key in permissions[sheet_name].keys():
         for group in permissions[sheet_name][wiki_key].keys():

--- a/torquedata/torquedata/__init__.py
+++ b/torquedata/torquedata/__init__.py
@@ -170,7 +170,6 @@ def load_sheet(sheet_name):
     column_types = next(reader)
     for row in reader:
         o = {}
-        edit_o = {}
         for (field, column_type, cell) in zip(header, column_types, row):
             if column_type == "list":
                 # This may be reversed as a decision at some point, but the empty cell

--- a/torquedata/torquedata/routes.py
+++ b/torquedata/torquedata/routes.py
@@ -32,8 +32,8 @@ def search(sheet_name):
             # 2000 is arbitrarily large enough, and we must have a limit declared
             results = searcher.search(query, limit=2000)
 
-            search_templates = templates[sheet_name][wiki_key]['Search']
-            search_template = search_templates['templates'][search_templates['default']]
+            search_templates = templates[sheet_name][wiki_key]["Search"]
+            search_template = search_templates["templates"][search_templates["default"]]
             template = Template(search_template)
 
             config = sheet_config[sheet_name]
@@ -46,7 +46,10 @@ def search(sheet_name):
                 resp = "== %d results for '%s' ==\n\n" % (results.scored_length(), q)
                 for r in results:
                     o = data[sheet_name][r["key"]]
-                    culled_o = cull_invalid_columns(data[sheet_name][r["key"]], permissions[sheet_name][wiki_key][group]["columns"])
+                    culled_o = cull_invalid_columns(
+                        data[sheet_name][r["key"]],
+                        permissions[sheet_name][wiki_key][group]["columns"],
+                    )
                     resp += template.render({config["object_name"]: culled_o})
                     resp += "\n\n"
 
@@ -55,60 +58,81 @@ def search(sheet_name):
         return ""
 
 
-@app.route('/api/<sheet_name>.<fmt>')
+@app.route("/api/<sheet_name>.<fmt>")
 def sheet(sheet_name, fmt):
     group = request.args.get("group")
     wiki_key = request.args.get("wiki_key")
 
     if fmt == "json":
         valid_objects = cull_invalid_objects(group, sheet_name, wiki_key)
-        return json.dumps({sheet_name: [cull_invalid_columns(o, permissions[sheet_name][wiki_key][group]["columns"]) for o in valid_objects ]})
+        return json.dumps(
+            {
+                sheet_name: [
+                    cull_invalid_columns(
+                        o, permissions[sheet_name][wiki_key][group]["columns"]
+                    )
+                    for o in valid_objects
+                ]
+            }
+        )
     else:
         raise Exception("Only json format valid for full list")
 
 
-@app.route('/api/<sheet_name>/toc/<toc_name>.<fmt>')
+@app.route("/api/<sheet_name>/toc/<toc_name>.<fmt>")
 def sheet_toc(sheet_name, toc_name, fmt):
     group = request.args.get("group")
     wiki_key = request.args.get("wiki_key")
 
     if not group:
-        abort(403, "Group " + group + " invalid");
+        abort(403, "Group " + group + " invalid")
 
-    if not 'TOC' in templates[sheet_name][wiki_key]:
-        abort(403, "No TOC defined for " + sheet_name + " for wiki " + wiki_key);
+    if not "TOC" in templates[sheet_name][wiki_key]:
+        abort(403, "No TOC defined for " + sheet_name + " for wiki " + wiki_key)
 
     valid_objects = cull_invalid_objects(group, sheet_name, wiki_key)
 
     if fmt == "mwiki":
         toc_str = ""
         config = sheet_config[sheet_name]
-        with open(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "tocs", toc_name + ".j2")) as f:
+        with open(
+            os.path.join(
+                app.config["SPREADSHEET_FOLDER"], sheet_name, "tocs", toc_name + ".j2"
+            )
+        ) as f:
             template_str = f.read()
-        with open(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "tocs", toc_name + ".json")) as f:
+        with open(
+            os.path.join(
+                app.config["SPREADSHEET_FOLDER"], sheet_name, "tocs", toc_name + ".json"
+            )
+        ) as f:
             template_data = json.loads(f.read())
-        template_data[sheet_name] = { o[config["key_column"]]:o for o in valid_objects }
+        template_data[sheet_name] = {o[config["key_column"]]: o for o in valid_objects}
 
-        toc_templates = templates[sheet_name][wiki_key]['TOC']
+        toc_templates = templates[sheet_name][wiki_key]["TOC"]
 
-        toc_template = toc_templates['templates'][toc_templates['default']]
+        toc_template = toc_templates["templates"][toc_templates["default"]]
 
         # Because TorqueDataConnect will sometimes override the global view and send it along,
         # and because that view may not be a valid TOC view, only use the view argument to override
         # the default if it's valid.
-        if request.args.get("view") and request.args.get("view") in toc_templates['templates']:
-            toc_template = toc_templates['templates'][request.args.get("view")]
+        if (
+            request.args.get("view")
+            and request.args.get("view") in toc_templates["templates"]
+        ):
+            toc_template = toc_templates["templates"][request.args.get("view")]
 
         template = Template(toc_template)
-        template_data['toc_lines'] = {
-                o[config['key_column']]:
-                    template.render({
-                        config['object_name']:
-                        cull_invalid_columns(o, permissions[sheet_name][wiki_key][group]["columns"])
-                    })
-                for o
-                in valid_objects
-            }
+        template_data["toc_lines"] = {
+            o[config["key_column"]]: template.render(
+                {
+                    config["object_name"]: cull_invalid_columns(
+                        o, permissions[sheet_name][wiki_key][group]["columns"]
+                    )
+                }
+            )
+            for o in valid_objects
+        }
 
         return Template(template_str).render(template_data)
     else:
@@ -116,34 +140,41 @@ def sheet_toc(sheet_name, toc_name, fmt):
 
 
 def is_valid_id(group, wiki_key, key, sheet_name):
-    if wiki_key in permissions[sheet_name].keys() and group in permissions[sheet_name][wiki_key].keys():
+    if (
+        wiki_key in permissions[sheet_name].keys()
+        and group in permissions[sheet_name][wiki_key].keys()
+    ):
         if "valid_ids" not in permissions[sheet_name][wiki_key][group].keys():
             return True
         else:
-            return (key in permissions[sheet_name][wiki_key][group]["valid_ids"])
+            return key in permissions[sheet_name][wiki_key][group]["valid_ids"]
 
 
 def get_row(group, wiki_key, key, fmt, sheet_name, view=None):
     if not is_valid_id(group, wiki_key, key, sheet_name):
         if fmt == "json":
-            return json.dumps({"error": "Invalid " + sheet_config[sheet_name]["key_column"]})
+            return json.dumps(
+                {"error": "Invalid " + sheet_config[sheet_name]["key_column"]}
+            )
         else:
-            abort(403, "Invalid " + sheet_config[sheet_name]["key_column"]);
+            abort(403, "Invalid " + sheet_config[sheet_name]["key_column"])
 
     row = data[sheet_name][key]
 
     if "columns" in permissions[sheet_name][wiki_key][group]:
-        row = cull_invalid_columns(row, permissions[sheet_name][wiki_key][group]["columns"])
+        row = cull_invalid_columns(
+            row, permissions[sheet_name][wiki_key][group]["columns"]
+        )
 
     row = update_row_with_edits(row, sheet_name, key)
 
     if fmt == "json":
         return json.dumps(row)
     elif fmt == "mwiki":
-        mwiki_templates = templates[sheet_name][wiki_key]['View']
-        chosen_view = view or mwiki_templates['default']
+        mwiki_templates = templates[sheet_name][wiki_key]["View"]
+        chosen_view = view or mwiki_templates["default"]
         config = sheet_config[sheet_name]
-        mwiki_template = mwiki_templates['templates'][chosen_view]
+        mwiki_template = mwiki_templates["templates"][chosen_view]
         template = Template(mwiki_template)
 
         return template.render({config["object_name"]: row})
@@ -151,7 +182,7 @@ def get_row(group, wiki_key, key, fmt, sheet_name, view=None):
         raise Exception("Invalid format: " + fmt)
 
 
-@app.route('/api/<sheet_name>/edit-record/<key>', methods=['POST'])
+@app.route("/api/<sheet_name>/edit-record/<key>", methods=["POST"])
 def edit_record(sheet_name, key):
     group = request.json.get("group")
     wiki_key = request.json.get("wiki_key")
@@ -169,40 +200,45 @@ def edit_record(sheet_name, key):
             "approver": None,
             "approval_code": None,
             "approval_timestamp": None,
-            "wiki_key": wiki_key
+            "wiki_key": wiki_key,
         }
         edits[sheet_name][key][field]["edits"].append(edit)
 
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "edits"), 'wb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "edits"), "wb") as f:
         pickle.dump(edits, f)
 
     return get_row(group, wiki_key, key, "mwiki", sheet_name)
 
 
-@app.route('/api/<sheet_name>/id/<key>.<fmt>')
+@app.route("/api/<sheet_name>/id/<key>.<fmt>")
 def row(sheet_name, key, fmt):
     group = request.args.get("group")
     wiki_key = request.args.get("wiki_key")
 
-    return get_row(group, wiki_key, key, fmt, sheet_name,
-                   request.args.get("view", None))
+    return get_row(
+        group, wiki_key, key, fmt, sheet_name, request.args.get("view", None)
+    )
 
 
-@app.route('/api/<sheet_name>/attachment/<key>/<attachment>')
+@app.route("/api/<sheet_name>/attachment/<key>/<attachment>")
 def attachment(sheet_name, key, attachment):
     group = request.args.get("group")
     wiki_key = request.args.get("wiki_key")
 
     import urllib.parse
+
     attachment = urllib.parse.unquote_plus(attachment)
 
     valid_id = False
 
-    if wiki_key in permissions[sheet_name].keys() and group in permissions[sheet_name][wiki_key].keys():
+    if (
+        wiki_key in permissions[sheet_name].keys()
+        and group in permissions[sheet_name][wiki_key].keys()
+    ):
         if "valid_ids" not in permissions[sheet_name][wiki_key][group].keys():
             valid_id = True
         else:
-            valid_id = (key in permissions[sheet_name][wiki_key][group]["valid_ids"])
+            valid_id = key in permissions[sheet_name][wiki_key][group]["valid_ids"]
 
     if not valid_id:
         return "Invalid " + sheet_config[sheet_name]["key_column"]
@@ -214,60 +250,78 @@ def attachment(sheet_name, key, attachment):
     if attachment_config[attachment_name]["object_id"] != key:
         return "Invalid " + sheet_config[sheet_name]["key_column"]
 
-    attachment_permissions_column = attachment_config[attachment_name]["permissions_column"]
-    if attachment_permissions_column not in permissions[sheet_name][wiki_key][group]["columns"]:
+    attachment_permissions_column = attachment_config[attachment_name][
+        "permissions_column"
+    ]
+    if (
+        attachment_permissions_column
+        not in permissions[sheet_name][wiki_key][group]["columns"]
+    ):
         return "Invalid attachment: " + attachment_name
 
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "attachments", attachment_name), "rb") as file:
-        return send_file(io.BytesIO(file.read()), attachment_filename = attachment_name)
+    with open(
+        os.path.join(
+            app.config["SPREADSHEET_FOLDER"], sheet_name, "attachments", attachment_name
+        ),
+        "rb",
+    ) as file:
+        return send_file(io.BytesIO(file.read()), attachment_filename=attachment_name)
 
 
-@app.route('/upload/sheet', methods=['POST'])
+@app.route("/upload/sheet", methods=["POST"])
 def upload_sheet():
-    if 'data_file' not in request.files:
+    if "data_file" not in request.files:
         raise Exception("Must have file in data upload")
-    if 'object_name' not in request.form:
+    if "object_name" not in request.form:
         raise Exception("Must have the object_name")
-    if 'sheet_name' not in request.form:
+    if "sheet_name" not in request.form:
         raise Exception("Must have the sheet_name")
-    if 'key_column' not in request.form:
+    if "key_column" not in request.form:
         raise Exception("Must have the key_column name")
 
-    file = request.files['data_file']
-    if file.filename == '':
+    file = request.files["data_file"]
+    if file.filename == "":
         raise Exception("File must have a filename associated with it")
     if file:
-        sheet_name = secure_filename(request.form['sheet_name'])
+        sheet_name = secure_filename(request.form["sheet_name"])
 
         try:
-            os.mkdir(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name))
+            os.mkdir(os.path.join(app.config["SPREADSHEET_FOLDER"], sheet_name))
         except FileExistsError:
             pass
 
         try:
-            os.mkdir(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "tocs"))
+            os.mkdir(os.path.join(app.config["SPREADSHEET_FOLDER"], sheet_name, "tocs"))
         except FileExistsError:
             pass
 
         try:
-            dir = os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "indices")
+            dir = os.path.join(app.config["SPREADSHEET_FOLDER"], sheet_name, "indices")
             shutil.rmtree(dir, True)
             os.mkdir(dir)
         except FileExistsError:
             pass
 
         try:
-            os.mkdir(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "attachments"))
+            os.mkdir(
+                os.path.join(
+                    app.config["SPREADSHEET_FOLDER"], sheet_name, "attachments"
+                )
+            )
         except FileExistsError:
             pass
 
-        file.save(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, sheet_name + ".csv"))
+        file.save(
+            os.path.join(
+                app.config["SPREADSHEET_FOLDER"], sheet_name, sheet_name + ".csv"
+            )
+        )
 
         sheet_config[sheet_name] = {}
-        sheet_config[sheet_name]["object_name"] = request.form['object_name']
-        sheet_config[sheet_name]["sheet_name"] = request.form['sheet_name']
-        sheet_config[sheet_name]["key_column"] = request.form['key_column']
-        with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "sheets"), 'w') as f:
+        sheet_config[sheet_name]["object_name"] = request.form["object_name"]
+        sheet_config[sheet_name]["sheet_name"] = request.form["sheet_name"]
+        sheet_config[sheet_name]["key_column"] = request.form["key_column"]
+        with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "sheets"), "w") as f:
             sheet_config.write(f)
 
         load_sheet(sheet_name)
@@ -275,21 +329,21 @@ def upload_sheet():
     return ""
 
 
-@app.route('/config/<sheet_name>/<wiki_key>/reset')
+@app.route("/config/<sheet_name>/<wiki_key>/reset")
 def reset_config(sheet_name, wiki_key):
     global templates, permissions
     permissions[sheet_name][wiki_key] = {}
     templates[sheet_name][wiki_key] = {}
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "permissions"), 'wb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "permissions"), "wb") as f:
         pickle.dump(permissions, f)
 
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "templates"), 'wb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "templates"), "wb") as f:
         pickle.dump(templates, f)
 
-    return ''
+    return ""
 
 
-@app.route('/config/<sheet_name>/<wiki_key>/group', methods=['POST'])
+@app.route("/config/<sheet_name>/<wiki_key>/group", methods=["POST"])
 def set_group_config(sheet_name, wiki_key):
     global permissions
     new_config = request.json
@@ -300,35 +354,37 @@ def set_group_config(sheet_name, wiki_key):
     if wiki_key not in permissions[sheet_name].keys():
         permissions[sheet_name][wiki_key] = {}
 
-    if 'group' not in new_config:
+    if "group" not in new_config:
         raise Exception("Must have a group name")
 
-    group_name = new_config['group']
+    group_name = new_config["group"]
     if group_name not in permissions[sheet_name][wiki_key].keys():
         permissions[sheet_name][wiki_key][group_name] = {}
 
-    if 'valid_ids' in new_config:
-        permissions[sheet_name][wiki_key][group_name]['valid_ids'] = new_config['valid_ids']
+    if "valid_ids" in new_config:
+        permissions[sheet_name][wiki_key][group_name]["valid_ids"] = new_config[
+            "valid_ids"
+        ]
 
-    if 'columns' in new_config:
-        permissions[sheet_name][wiki_key][group_name]['columns'] = new_config['columns']
+    if "columns" in new_config:
+        permissions[sheet_name][wiki_key][group_name]["columns"] = new_config["columns"]
 
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "permissions"), 'wb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "permissions"), "wb") as f:
         pickle.dump(permissions, f)
 
     index_search(group_name, sheet_name, wiki_key)
 
-    return ''
+    return ""
 
 
-@app.route('/config/<sheet_name>/<wiki_key>/template', methods=['POST'])
+@app.route("/config/<sheet_name>/<wiki_key>/template", methods=["POST"])
 def set_template_config(sheet_name, wiki_key):
     new_config = request.json
 
-    if 'name' not in new_config:
+    if "name" not in new_config:
         raise Exception("Must have a template name")
 
-    if 'type' not in new_config:
+    if "type" not in new_config:
         raise Exception("Must have a template type")
 
     if sheet_name not in templates.keys():
@@ -337,95 +393,111 @@ def set_template_config(sheet_name, wiki_key):
     if wiki_key not in templates[sheet_name].keys():
         templates[sheet_name][wiki_key] = {}
 
-    template_type = new_config['type']
+    template_type = new_config["type"]
     if template_type not in templates[sheet_name][wiki_key]:
         templates[sheet_name][wiki_key][template_type] = {
-                'default': None,
-                'templates': {}
-                }
+            "default": None,
+            "templates": {},
+        }
 
-    name = new_config['name']
-    if name not in templates[sheet_name][wiki_key][template_type]['templates']:
+    name = new_config["name"]
+    if name not in templates[sheet_name][wiki_key][template_type]["templates"]:
         # We just make the first one we get the default for the type
-        if not templates[sheet_name][wiki_key][template_type]['default']:
-            templates[sheet_name][wiki_key][template_type]['default'] = name
-        templates[sheet_name][wiki_key][template_type]['templates'][name] = new_config['template']
+        if not templates[sheet_name][wiki_key][template_type]["default"]:
+            templates[sheet_name][wiki_key][template_type]["default"] = name
+        templates[sheet_name][wiki_key][template_type]["templates"][name] = new_config[
+            "template"
+        ]
 
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "templates"), 'wb') as f:
+    with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "templates"), "wb") as f:
         pickle.dump(templates, f)
-
-    return ''
-
-
-@app.route('/upload/toc', methods=['POST'])
-def upload_toc():
-    from werkzeug.utils import secure_filename
-
-    if 'json' not in request.files:
-        raise Exception("Must have json file")
-    if 'template' not in request.files:
-        raise Exception("Must have template file")
-    if 'sheet_name' not in request.form:
-        raise Exception("Must have the sheet_name")
-    if 'toc_name' not in request.form:
-        raise Exception("Must have the toc_name")
-
-    json_file = request.files['json']
-    template_file = request.files['template']
-    sheet_name = secure_filename(request.form['sheet_name'])
-    toc_name = secure_filename(request.form['toc_name'])
-
-    if json_file.filename == '':
-        raise Exception("json_file must have a filename associated with it")
-    if template_file.filename == '':
-        raise Exception("template_file must have a filename associated with it")
-    if sheet_name not in sheet_config.keys():
-        raise Exception(sheet_name + " is not an existing sheet")
-    if json_file and template_file:
-        secure_sheet_name = secure_filename(request.form['sheet_name'])
-
-        json_file.save(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "tocs", toc_name + ".json"))
-        template_file.save(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "tocs", toc_name + ".j2"))
 
     return ""
 
 
-@app.route('/upload/attachment', methods=['POST'])
+@app.route("/upload/toc", methods=["POST"])
+def upload_toc():
+    from werkzeug.utils import secure_filename
+
+    if "json" not in request.files:
+        raise Exception("Must have json file")
+    if "template" not in request.files:
+        raise Exception("Must have template file")
+    if "sheet_name" not in request.form:
+        raise Exception("Must have the sheet_name")
+    if "toc_name" not in request.form:
+        raise Exception("Must have the toc_name")
+
+    json_file = request.files["json"]
+    template_file = request.files["template"]
+    sheet_name = secure_filename(request.form["sheet_name"])
+    toc_name = secure_filename(request.form["toc_name"])
+
+    if json_file.filename == "":
+        raise Exception("json_file must have a filename associated with it")
+    if template_file.filename == "":
+        raise Exception("template_file must have a filename associated with it")
+    if sheet_name not in sheet_config.keys():
+        raise Exception(sheet_name + " is not an existing sheet")
+    if json_file and template_file:
+        secure_sheet_name = secure_filename(request.form["sheet_name"])
+
+        json_file.save(
+            os.path.join(
+                app.config["SPREADSHEET_FOLDER"], sheet_name, "tocs", toc_name + ".json"
+            )
+        )
+        template_file.save(
+            os.path.join(
+                app.config["SPREADSHEET_FOLDER"], sheet_name, "tocs", toc_name + ".j2"
+            )
+        )
+
+    return ""
+
+
+@app.route("/upload/attachment", methods=["POST"])
 def upload_attachment():
     from werkzeug.utils import secure_filename
 
-    if 'attachment' not in request.files:
+    if "attachment" not in request.files:
         raise Exception("Must have file in data upload")
-    if 'attachment_name' not in request.form:
+    if "attachment_name" not in request.form:
         raise Exception("Must have the attachment_name")
-    if 'sheet_name' not in request.form:
+    if "sheet_name" not in request.form:
         raise Exception("Must have the sheet_name")
-    if 'permissions_column' not in request.form:
+    if "permissions_column" not in request.form:
         raise Exception("Must have the permissions_column")
-    if 'object_id' not in request.form:
+    if "object_id" not in request.form:
         raise Exception("Must have the object_id name")
 
-    attachment = request.files['attachment']
-    if attachment.filename == '':
+    attachment = request.files["attachment"]
+    if attachment.filename == "":
         raise Exception("attachment must have a filename associated with it")
 
-    sheet_name = secure_filename(request.form['sheet_name'])
+    sheet_name = secure_filename(request.form["sheet_name"])
     if sheet_name not in sheet_config.keys():
         raise Exception(sheet_name + " is not an existing sheet")
 
-    attachment_name = secure_filename(request.form['attachment_name'])
-    permissions_column = request.form['permissions_column']
-    object_id = request.form['object_id']
+    attachment_name = secure_filename(request.form["attachment_name"])
+    permissions_column = request.form["permissions_column"]
+    object_id = request.form["object_id"]
 
     attachment_config[attachment_name] = {
-            'permissions_column': permissions_column,
-            'object_id': object_id
-            }
+        "permissions_column": permissions_column,
+        "object_id": object_id,
+    }
 
-    with open(os.path.join(app.config['SPREADSHEET_FOLDER'], "attachment_config"), 'wb') as f:
+    with open(
+        os.path.join(app.config["SPREADSHEET_FOLDER"], "attachment_config"), "wb"
+    ) as f:
         pickle.dump(attachment_config, f)
 
-    attachment.save(os.path.join(app.config['SPREADSHEET_FOLDER'], sheet_name, "attachments", attachment_name))
+    attachment.save(
+        os.path.join(
+            app.config["SPREADSHEET_FOLDER"], sheet_name, "attachments", attachment_name
+        )
+    )
 
     return ""
 
@@ -435,7 +507,7 @@ def upload_attachment():
 userlock = threading.Lock()
 
 
-@app.route('/users/username/<username>')
+@app.route("/users/username/<username>")
 def find_user_by_username(username):
     if username not in users.keys():
         with userlock:
@@ -443,9 +515,9 @@ def find_user_by_username(username):
             users[username] = {"username": username, "id": len(users.items()) + 14}
 
             # With help from https://stackoverflow.com/questions/2333872/atomic-writing-to-file-with-python
-            filepath = os.path.join(app.config['SPREADSHEET_FOLDER'], "users")
-            tmppath = filepath + '~'
-            with open(tmppath, 'wb') as f:
+            filepath = os.path.join(app.config["SPREADSHEET_FOLDER"], "users")
+            tmppath = filepath + "~"
+            with open(tmppath, "wb") as f:
                 pickle.dump(users, f)
                 f.flush()
                 os.fsync(f.fileno())

--- a/torquedata/torquedata/routes.py
+++ b/torquedata/torquedata/routes.py
@@ -148,6 +148,7 @@ def is_valid_id(group, wiki_key, key, sheet_name):
             return True
         else:
             return key in permissions[sheet_name][wiki_key][group]["valid_ids"]
+    return False
 
 
 def get_row(group, wiki_key, key, fmt, sheet_name, view=None):

--- a/torquedata/torquedata/routes.py
+++ b/torquedata/torquedata/routes.py
@@ -179,8 +179,19 @@ def get_row(group, wiki_key, key, fmt, sheet_name, view=None):
         template = Template(mwiki_template)
 
         return template.render({config["object_name"]: row})
+    elif fmt == "dict":
+        return row
     else:
         raise Exception("Invalid format: " + fmt)
+
+
+@app.route("/api/<sheet_name>/id/<key>/<field>")
+def get_cell(sheet_name, key, field):
+    group = request.args.get("group")
+    wiki_key = request.args.get("wiki_key")
+
+    row = get_row(group, wiki_key, key, "dict", sheet_name, None)
+    return json.dumps({"field": row[field]})
 
 
 @app.route("/api/<sheet_name>/edit-record/<key>", methods=["POST"])

--- a/torquedata/torquedata/routes.py
+++ b/torquedata/torquedata/routes.py
@@ -208,7 +208,7 @@ def edit_record(sheet_name, key):
     with open(os.path.join(app.config["SPREADSHEET_FOLDER"], "edits"), "wb") as f:
         pickle.dump(edits, f)
 
-    return get_row(group, wiki_key, key, "mwiki", sheet_name)
+    return True
 
 
 @app.route("/api/<sheet_name>/id/<key>.<fmt>")


### PR DESCRIPTION
# Overview

In #32 we describe that it may be useful for users to be able to edit fields which are contained in torque through the mediawiki UI. This PR adds the ability to do so through a basic inline textbox edit interface.

# Screenshots

![screenshot_2020-08-13-170626](https://user-images.githubusercontent.com/2600677/90158934-921e3c80-dd87-11ea-99fb-417ab678498f.png)
![screenshot_2020-08-13-170650](https://user-images.githubusercontent.com/2600677/90158932-921e3c80-dd87-11ea-9365-4539c54bcd6c.png)
![screenshot_2020-08-13-170700](https://user-images.githubusercontent.com/2600677/90158928-9185a600-dd87-11ea-83c4-b29c1b7f598c.png)
![screenshot_2020-08-13-170714](https://user-images.githubusercontent.com/2600677/90158925-90ed0f80-dd87-11ea-8f52-e5d509a6bd3c.png)

# Features

- [x]  Inline editing of paragraph and list elements
- [x]  Logging of edits within `Special:Log`
- [x]  Separate database of edits to be rolled back in the future

This PR doesn't include a few things however such as

- [ ]  An interface for comparing edit diffs and reverting edits
- [ ]  Specific functionality only allowing certain users to edit certain fields
