### PR TITLE
Add pagination to search, and speed it up

### DIFF
--- a/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
+++ b/TorqueDataConnect/include/hooks/TorqueDataConnectHooks.php
@@ -121,6 +121,8 @@ class TorqueDataConnectHooks {
       $wgTorqueDataConnectWikiKey, $wgTorqueDataConnectServerLocation,
       $wgTorqueDataConnectMultiWikiConfig;
 
+    $offset = $specialSearch->getRequest()->getInt("offset", 0);
+
     if($wgTorqueDataConnectMultiWikiConfig) {
       $wiki_keys = "";
       $sheet_names = "";
@@ -136,6 +138,7 @@ class TorqueDataConnectHooks {
         "&sheet_name=" . $wgTorqueDataConnectSheetName .
         "&wiki_keys=" . $wiki_keys .
         "&sheet_names=" . $sheet_names .
+        "&offset=" . $offset .
         "&q=" .  urlencode($term)
         );
     } else {
@@ -144,11 +147,37 @@ class TorqueDataConnectHooks {
         "/api/sheets/" .  $wgTorqueDataConnectSheetName . "/search.mwiki" .
         "?group=" .  $wgTorqueDataConnectGroup .
         "&wiki_key=" .  $wgTorqueDataConnectWikiKey .
+        "&offset=" . $offset .
         "&q=" .  urlencode($term)
         );
     }
+    $split_point = strpos($results, " ");
+    $num_results = intval(substr($results, 0, $split_point));
+    $mwiki_results = substr($results, $split_point + 1);
+    $request = $specialSearch->getRequest();
 
-    $output->addWikiTextAsInterface($results);
+    $header = "<h2>$num_results results for '$term'";
+    if($num_results > 20) {
+      $header .= " (viewing ";
+      $header .= ($offset + 1) . " - " . min($num_results, ($offset + 20));
+      if($offset > 0) {
+        $header .= " | ";
+        $request->appendQueryValue("offset", ($offset - 20));
+        $prev_20_url = $output->getTitle()->getFullUrl(["offset" => $offset - 20, "search" => $term]);
+        $header .= "<a href='$prev_20_url'>Prev 20</a>";
+      }
+      if(($offset + 20) < $num_results) {
+        $header .= " | ";
+        $request->appendQueryValue("offset", ($offset + 20));
+        $next_20_url = $output->getTitle()->getFullUrl(["offset" => $offset + 20, "search" => $term]);
+        $header .= "<a href='$next_20_url'>Next 20</a>";
+      }
+      $header .= ")";
+    }
+    $header .= "</h2>";
+
+    $output->addHTML($header);
+    $output->addWikiTextAsInterface($mwiki_results);
 
     return false;
   }

--- a/torquedata/core/views.py
+++ b/torquedata/core/views.py
@@ -3,7 +3,7 @@ import urllib.parse
 from werkzeug.utils import secure_filename
 from datetime import datetime
 from django.core.files.base import ContentFile
-from django.db.models import Q
+from django.db.models import Q, F
 from django.db import transaction
 from django.http import HttpResponse, JsonResponse, FileResponse
 from django.views.decorators.http import require_http_methods
@@ -30,7 +30,7 @@ def get_wiki_key(request, sheet_name):
     return wiki_key
 
 
-def search(q, template_config, sheet_configs, fmt, multi):
+def search(q, offset, template_config, sheet_configs, fmt, multi):
     results = (
         models.SearchCacheRow.objects.filter(
             sheet__in=sheet_configs.values_list("sheet", flat=True),
@@ -41,17 +41,14 @@ def search(q, template_config, sheet_configs, fmt, multi):
         )
         .select_related("row")
         .select_related("sheet")
-        .annotate(rank=SearchRank(SearchVector("data"), SearchQuery(q)))
+        .annotate(rank=SearchRank(F("data_vector"), SearchQuery(q)))
         .order_by("-rank")
     )
 
     if fmt == "mwiki":
-        addendum = ""
-        if results.count() > 100:
-            addendum = " (showing top 100)"
-        resp = f"== {results.count()} results for '{q}'{addendum} == \n\n"
+        resp = ""
 
-        for result in results[:100]:
+        for result in results[offset : (offset + 20)]:
             template = JinjaTemplate(
                 models.Template.objects.get(
                     name="Search", sheet=template_config.sheet
@@ -66,7 +63,7 @@ def search(q, template_config, sheet_configs, fmt, multi):
             )
             resp += "\n\n"
 
-        return HttpResponse(resp)
+        return HttpResponse(str(results.count()) + " " + resp)
     elif fmt == "json":
         response = [
             "/%s/%s/%s/%s"
@@ -86,6 +83,7 @@ def search(q, template_config, sheet_configs, fmt, multi):
 
 def search_global(request, fmt):
     q = request.GET["q"]
+    offset = int(request.GET["offset"])
     group = request.GET["group"]
     global_wiki_key = request.GET["wiki_key"]
     global_sheet_name = request.GET["sheet_name"]
@@ -97,17 +95,18 @@ def search_global(request, fmt):
     configs = models.SheetConfig.objects.filter(
         sheet__name__in=sheet_names, wiki_key__in=wiki_keys, group=group
     ).all()
-    return search(q, global_config, configs, fmt, True)
+    return search(q, offset, global_config, configs, fmt, True)
 
 
 def search_sheet(request, sheet_name, fmt):
     q = request.GET["q"]
+    offset = int(request.GET["offset"])
     group = request.GET["group"]
     wiki_key = get_wiki_key(request, sheet_name)
     configs = models.SheetConfig.objects.filter(
         sheet__name=sheet_name, wiki_key=wiki_key, group=group
     )
-    return search(q, configs.first(), configs, fmt, False)
+    return search(q, offset, configs.first(), configs, fmt, False)
 
 
 def edit_record(sheet_name, key, group, wiki_key, field, new_value):
@@ -152,7 +151,6 @@ def get_sheet(request, sheet_name, fmt):
     if fmt == "json":
         response = {"name": sheet_name}
 
-
         sheet = models.Spreadsheet.objects.get(name=sheet_name)
 
         if "group" in request.GET:
@@ -168,9 +166,7 @@ def get_sheet(request, sheet_name, fmt):
                 column.name for column in sheet_config.valid_columns.all()
             ]
         else:
-            response["fields"] = [
-                column.name for column in sheet.columns.all()
-            ]
+            response["fields"] = [column.name for column in sheet.columns.all()]
 
         response["last_updated"] = sheet.last_updated.isoformat()
 


### PR DESCRIPTION
Required passing back the total search results so that the mediawiki
extension can create the pagination.  Otherwise, the big speedup was
using the django F() function to use the pre-calculated ts_vector field
for ranking rather than rebuilding it each time.

PR Note: I'll merge this late this week if you don't have a chance to look at it so that I can push it to production.