### PR TITLE
Create function for getting configured groups

### DIFF
--- a/TorqueDataConnect/include/TorqueDataConnectConfig.php
+++ b/TorqueDataConnect/include/TorqueDataConnectConfig.php
@@ -275,11 +275,19 @@ class TorqueDataConnectConfig {
   public static function getValidGroup($user) {
     $manager = MediaWiki\MediaWikiServices::getInstance()->getUserGroupManager();
     $wikiGroups = $manager->getUserGroups($user);
-    foreach(TorqueDataConnectConfig::parseConfig()[0] as $group) {
-      if(in_array($group["groupName"], $wikiGroups) {
-        return $group["groupName"];
+    foreach(TorqueDataConnectConfig::getConfiguredGroups() as $group) {
+      if(in_array($group, $wikiGroups) {
+        return $group;
       }
     }
+  }
+
+  public static function getConfiguredGroups() {
+    $groupNames = [];
+    foreach(TorqueDataConnectConfig::parseConfig()[0] as $group) {
+      array_push($groupNames, $group["groupName"]);
+    }
+    return $groupNames;
   }
 }
 


### PR DESCRIPTION
This is useful for outside code that may want to know what configured
groups are available from torque.  This way toplevel configuration
(e.g., in LocalSettings.php) can do intelligent things based on what
groups are available.